### PR TITLE
After test party

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A program and toolsets for distributing tokens efficiently via uploading a [Merk
 
 Thanks Jito for excellent [Merkle-distributor project](https://github.com/jito-foundation/distributor). In Jupiter, We fork the project and add some extra steps to make it works for a large set of addresses. 
 
-There are issues if uploading the large number of addresses to a single merkle tree:
+There are issues if the number of airdrop addresses increases:
 - The size of the proof increases, that may be over solana transaction size limit.
 - Too many write locked accounts duration hot claming event, so only some transactions are get through. 
 
@@ -15,34 +15,26 @@ In order to tackle it, we break the large set of addresses to smaller merkle tre
 Before are follow toolset to build sharding merkle trees
 
 ## CLI
-
 Build and deploy sharding merkle trees:
 
 ```
 cd cli
-
 cargo build
-
 ../target/debug/cli create-merkle-tree --csv-path [PATH_TO_LARGE_SET_OF_ADDRESS] --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES] --max-nodes-per-tree 12000
-
-../target/debug/cli --mint [TOKEN_MINT] --keypair-path [KEYPAIR_PATH] --rpc-url [RPC] new-distributor --start-vesting-ts [START_VESTING] --end-vesting-ts [END_VESTING] --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES] --clawback-start-ts [CLAWBACK_START] --enable-slot [ENABLE_SLOT]
-
-../target/debug/cli --mint [TOKEN_MINT] --keypair-path [KEYPAIR_PATH] --rpc-url [RPC] fund-all --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES]
+../target/debug/cli --mint [TOKEN_MINT] --keypair-path [KEY_PAIR] --rpc-url [RPC] new-distributor --start-vesting-ts [START_VESTING] --end-vesting-ts [END_VESTING] --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES] --clawback-start-ts [CLAWBACK_START] --enable-slot [ENABLE_SLOT]
+../target/debug/cli --mint [TOKEN_MINT] --keypair-path [KEY_PAIR] --rpc-url [RPC] fund-all --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES]
 ```
 
 Anyone can verify the whole setup after that:
 
 ```
-../target/debug/cli --mint [TOKEN_MINT] --keypair-path [KEYPAIR_PATH] --rpc-url [RPC] verify --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES] --clawback-start-ts [CLAWBACK_START] --enable-slot [ENABLE_SLOT] --admin [ADMIN]
+../target/debug/cli --mint [TOKEN_MINT] --keypair-path [KEY_PAIR] --rpc-url [RPC] verify --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES] --clawback-start-ts [CLAWBACK_START] --enable-slot [ENABLE_SLOT] --admin [ADMIN]
 ```
 
 ## API
-
 We can host API in local server 
 ```
 cd api
-
 cargo build
-
 ../target/debug/jupiter-airdrop-api --merkle-tree-path [PATH_TO_FOLDER_STORE_ALL_MERKLE_TREES] --rpc-url [RPC] --mint [TOKEN_MINT] --program-id [PROGRAM_ID]
 ```

--- a/cli/src/bin/cli.rs
+++ b/cli/src/bin/cli.rs
@@ -152,6 +152,9 @@ pub struct VerifyArgs {
 
     #[clap(long, env)]
     pub admin: Pubkey,
+
+    #[clap(long, env)]
+    pub closable: bool,
 }
 
 // NewDistributor subcommand args
@@ -178,6 +181,9 @@ pub struct NewDistributorArgs {
 
     #[clap(long, env)]
     pub airdrop_version: Option<u64>,
+
+    #[clap(long, env)]
+    pub closable: bool,
 
     #[clap(long, env)]
     pub skip_verify: bool,
@@ -373,6 +379,10 @@ fn check_distributor_onchain_matches(
 
         if distributor.enable_slot != new_distributor_args.enable_slot {
             return Err("enable_slot mismatch");
+        }
+
+        if distributor.closable != new_distributor_args.closable {
+            return Err("closable mismatch");
         }
 
         // TODO fix code

--- a/cli/src/bin/instructions/process_close_claim_status.rs
+++ b/cli/src/bin/instructions/process_close_claim_status.rs
@@ -1,5 +1,3 @@
-use std::mem::transmute;
-
 use anchor_client::solana_client::rpc_filter::{Memcmp, RpcFilterType};
 use merkle_distributor::state::claim_status::ClaimStatus;
 

--- a/cli/src/bin/instructions/process_close_claim_status.rs
+++ b/cli/src/bin/instructions/process_close_claim_status.rs
@@ -1,12 +1,22 @@
+use std::mem::transmute;
+
+use anchor_client::solana_client::rpc_filter::{Memcmp, RpcFilterType};
 use merkle_distributor::state::claim_status::ClaimStatus;
-use solana_sdk::compute_budget::ComputeBudgetInstruction;
 
 use crate::*;
 
 pub fn process_close_claim_status(args: &Args) {
     let program = args.get_program_client();
-
-    let claim_status_accounts: Vec<(Pubkey, ClaimStatus)> = program.accounts(vec![]).unwrap();
+    let true_bytes = unsafe { transmute::<bool, u8>(true) };
+    let claim_status_accounts: Vec<(Pubkey, ClaimStatus)> = program
+        .accounts(vec![
+            RpcFilterType::DataSize((8 + ClaimStatus::LEN) as u64),
+            RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                8 + 32 + 8 + 8,
+                true_bytes.to_le_bytes().to_vec(),
+            )),
+        ])
+        .unwrap();
     let keypair = read_keypair_file(&args.keypair_path.clone().unwrap())
         .expect("Failed reading keypair file");
     println!("num accounts {}", claim_status_accounts.len());

--- a/cli/src/bin/instructions/process_close_claim_status.rs
+++ b/cli/src/bin/instructions/process_close_claim_status.rs
@@ -7,13 +7,12 @@ use crate::*;
 
 pub fn process_close_claim_status(args: &Args) {
     let program = args.get_program_client();
-    let true_bytes = unsafe { transmute::<bool, u8>(true) };
     let claim_status_accounts: Vec<(Pubkey, ClaimStatus)> = program
         .accounts(vec![
             RpcFilterType::DataSize((8 + ClaimStatus::LEN) as u64),
             RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
-                8 + 32 + 8 + 8,
-                true_bytes.to_le_bytes().to_vec(),
+                8 + 32 + 8 + 8 + 8,
+                u8::from(true).to_le_bytes().to_vec(),
             )),
         ])
         .unwrap();

--- a/cli/src/bin/instructions/process_new_distributor.rs
+++ b/cli/src/bin/instructions/process_new_distributor.rs
@@ -87,6 +87,7 @@ pub fn process_new_distributor(args: &Args, new_distributor_args: &NewDistributo
                 end_vesting_ts: new_distributor_args.end_vesting_ts,
                 clawback_start_ts: new_distributor_args.clawback_start_ts,
                 enable_slot: new_distributor_args.enable_slot,
+                closable: new_distributor_args.closable,
             }
             .data(),
         });

--- a/cli/src/bin/instructions/process_verify.rs
+++ b/cli/src/bin/instructions/process_verify.rs
@@ -30,6 +30,8 @@ pub fn process_verify(args: &Args, verfify_args: &VerifyArgs) {
             verfify_args.clawback_start_ts
         );
 
+        assert_eq!(merke_tree_state.closable, verfify_args.closable);
+
         assert_eq!(merke_tree_state.admin, verfify_args.admin);
         assert_eq!(merke_tree_state.enable_slot, verfify_args.enable_slot);
         println!(

--- a/programs/merkle-distributor/Cargo.toml
+++ b/programs/merkle-distributor/Cargo.toml
@@ -14,7 +14,6 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
-test = []
 
 [dependencies]
 anchor-lang = "0.28.0"

--- a/programs/merkle-distributor/src/instructions/close_claim_status.rs
+++ b/programs/merkle-distributor/src/instructions/close_claim_status.rs
@@ -1,12 +1,6 @@
 use anchor_lang::{account, context::Context, prelude::*, Accounts, Key, ToAccountInfo};
-use solana_program::pubkey;
 
 use crate::{error::ErrorCode, state::claim_status::ClaimStatus};
-
-pub fn assert_eq_admin(sender: Pubkey) -> bool {
-    let admin = pubkey!("DHLXnJdACTY83yKwnUkeoDjqi4QBbsYGa1v8tJL76ViX");
-    sender == admin
-}
 
 // Accounts for [merkle_distributor::close_claim_status].
 #[derive(Accounts)]
@@ -14,6 +8,8 @@ pub struct CloseClaimStatus<'info> {
     #[account(
         mut,
         has_one = claimant,
+        has_one = admin,
+        constraint = claim_status.closable @ ErrorCode::CannotCloseClaimStatus,
         close = claimant,
     )]
     pub claim_status: Account<'info, ClaimStatus>,
@@ -22,18 +18,10 @@ pub struct CloseClaimStatus<'info> {
     #[account(mut)]
     pub claimant: UncheckedAccount<'info>,
 
-    #[account(constraint = assert_eq_admin(admin.key()) @ ErrorCode::Unauthorized)]
     pub admin: Signer<'info>,
 }
 
 #[allow(clippy::result_large_err)]
-#[cfg(feature = "test")]
 pub fn handle_close_status(ctx: Context<CloseClaimStatus>) -> Result<()> {
     Ok(())
-}
-
-#[allow(clippy::result_large_err)]
-#[cfg(not(feature = "test"))]
-pub fn handle_close_status(ctx: Context<CloseClaimStatus>) -> Result<()> {
-    return Err(ErrorCode::CannotCloseClaimStatus.into());
 }

--- a/programs/merkle-distributor/src/instructions/close_distributor.rs
+++ b/programs/merkle-distributor/src/instructions/close_distributor.rs
@@ -11,6 +11,7 @@ pub struct CloseDistributor<'info> {
         mut,
         has_one = admin,
         has_one = token_vault,
+        constraint = distributor.closable @ ErrorCode::CannotCloseDistributor,
         close = admin
     )]
     pub distributor: Account<'info, MerkleDistributor>,
@@ -33,7 +34,6 @@ pub struct CloseDistributor<'info> {
 }
 
 #[allow(clippy::result_large_err)]
-#[cfg(feature = "test")]
 pub fn handle_close_distributor(ctx: Context<CloseDistributor>) -> Result<()> {
     let distributor = &ctx.accounts.distributor;
     let seeds = [
@@ -56,10 +56,4 @@ pub fn handle_close_distributor(ctx: Context<CloseDistributor>) -> Result<()> {
         ctx.accounts.token_vault.amount,
     )?;
     Ok(())
-}
-
-#[allow(clippy::result_large_err)]
-#[cfg(not(feature = "test"))]
-pub fn handle_close_distributor(ctx: Context<CloseDistributor>) -> Result<()> {
-    return Err(ErrorCode::CannotCloseDistributor.into());
 }

--- a/programs/merkle-distributor/src/instructions/new_claim.rs
+++ b/programs/merkle-distributor/src/instructions/new_claim.rs
@@ -10,6 +10,7 @@ use jito_merkle_verify::verify;
 
 use crate::{
     error::ErrorCode,
+    merkle_distributor,
     state::{
         claim_status::ClaimStatus, claimed_event::NewClaimEvent,
         merkle_distributor::MerkleDistributor,
@@ -132,6 +133,8 @@ pub fn handle_new_claim(
     claim_status.locked_amount = amount_locked;
     claim_status.unlocked_amount = amount_unlocked;
     claim_status.locked_amount_withdrawn = 0;
+    claim_status.closable = distributor.closable;
+    claim_status.admin = distributor.admin;
 
     let seeds = [
         b"MerkleDistributor".as_ref(),

--- a/programs/merkle-distributor/src/instructions/new_distributor.rs
+++ b/programs/merkle-distributor/src/instructions/new_distributor.rs
@@ -78,6 +78,7 @@ pub fn handle_new_distributor(
     end_vesting_ts: i64,
     clawback_start_ts: i64,
     enable_slot: u64,
+    closable: bool,
 ) -> Result<()> {
     let curr_ts = Clock::get()?.unix_timestamp;
 
@@ -123,6 +124,7 @@ pub fn handle_new_distributor(
     distributor.admin = ctx.accounts.admin.key();
     distributor.clawed_back = false;
     distributor.enable_slot = enable_slot;
+    distributor.closable = closable;
 
     // Note: might get truncated, do not rely on
     msg! {

--- a/programs/merkle-distributor/src/lib.rs
+++ b/programs/merkle-distributor/src/lib.rs
@@ -53,6 +53,7 @@ pub mod merkle_distributor {
         end_vesting_ts: i64,
         clawback_start_ts: i64,
         enable_slot: u64,
+        closable: bool,
     ) -> Result<()> {
         handle_new_distributor(
             ctx,
@@ -64,6 +65,7 @@ pub mod merkle_distributor {
             end_vesting_ts,
             clawback_start_ts,
             enable_slot,
+            closable,
         )
     }
     /// only available in test phase

--- a/programs/merkle-distributor/src/state/claim_status.rs
+++ b/programs/merkle-distributor/src/state/claim_status.rs
@@ -14,6 +14,10 @@ pub struct ClaimStatus {
     pub locked_amount_withdrawn: u64,
     /// Unlocked amount
     pub unlocked_amount: u64,
+    /// indicate that whether admin can close this account, for testing purpose
+    pub closable: bool,
+    /// admin of merkle tree, store for for testing purpose
+    pub admin: Pubkey,
 }
 
 impl ClaimStatus {
@@ -65,153 +69,6 @@ impl ClaimStatus {
             }
         } else {
             Ok(0)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_normal_unlocking_scenario() {
-        let claim_status = ClaimStatus {
-            claimant: Pubkey::new_unique(),
-            locked_amount: 100,
-            unlocked_amount: 0,
-            locked_amount_withdrawn: 0,
-        };
-        let curr_ts = 50;
-        let start_ts = 0;
-        let end_ts = 100;
-        assert_eq!(
-            claim_status.unlocked_amount(curr_ts, start_ts, end_ts),
-            Ok(50)
-        );
-    }
-
-    #[test]
-    fn test_proportional_unlocking() {
-        let claim_status = ClaimStatus {
-            claimant: Pubkey::new_unique(),
-            locked_amount: 100,
-            locked_amount_withdrawn: 0,
-            unlocked_amount: 0,
-        };
-        let start_ts = 0;
-        let end_ts = 100;
-
-        assert_eq!(claim_status.unlocked_amount(0, start_ts, end_ts), Ok(0));
-        assert_eq!(claim_status.unlocked_amount(25, start_ts, end_ts), Ok(25));
-        assert_eq!(claim_status.unlocked_amount(50, start_ts, end_ts), Ok(50));
-        assert_eq!(claim_status.unlocked_amount(75, start_ts, end_ts), Ok(75));
-        assert_eq!(claim_status.unlocked_amount(100, start_ts, end_ts), Ok(100));
-    }
-
-    #[test]
-    fn test_unlocked_amount_no_truncation() {
-        // Test that even with the maximum possible values for curr_ts, start_ts, end_ts, and locked_amount,
-        // the unlocked_amount function will not truncate or overflow
-
-        let locked_amount = u64::MAX;
-
-        // Create a ClaimStatus instance
-        let claim_status = ClaimStatus {
-            claimant: Pubkey::new_unique(),
-            locked_amount,
-            unlocked_amount: 0,
-            locked_amount_withdrawn: 0,
-        };
-
-        // Use large values for time_into_unlock and total_unlock_time, but ensure they are within i64 range
-        let start_ts = 0;
-        let end_ts = i64::MAX;
-        for curr_ts in [0, (end_ts - start_ts) / 2, end_ts] {
-            // Calculate the expected amount without risking overflow or truncation
-            let time_into_unlock = (curr_ts - start_ts) as u128;
-            let total_unlock_time = (end_ts - start_ts) as u128;
-            let expected_amount = (time_into_unlock * locked_amount as u128) / total_unlock_time;
-
-            // Perform the calculation using the function
-            let calculated_amount = claim_status
-                .unlocked_amount(curr_ts, start_ts, end_ts)
-                .unwrap();
-
-            // Assert that the calculated amount matches the expected amount and is within u64 bounds
-            assert_eq!(calculated_amount as u128, expected_amount);
-            assert!(expected_amount <= u64::MAX as u128); // Ensure no truncation would occur
-        }
-    }
-
-    #[test]
-    fn test_unlocking_after_end_time() {
-        let claim_status = ClaimStatus {
-            claimant: Pubkey::new_unique(),
-            locked_amount: 100,
-            unlocked_amount: 0,
-            locked_amount_withdrawn: 0,
-        };
-        let curr_ts = 150;
-        let start_ts = 0;
-        let end_ts = 100;
-        assert_eq!(
-            claim_status.unlocked_amount(curr_ts, start_ts, end_ts),
-            Ok(100)
-        );
-    }
-
-    #[test]
-    fn test_division_by_zero() {
-        let claim_status = ClaimStatus {
-            claimant: Pubkey::new_unique(),
-            locked_amount: 100,
-            unlocked_amount: 0,
-            locked_amount_withdrawn: 0,
-        };
-        let curr_ts = 50;
-        let start_ts = 100;
-        let end_ts = 100;
-        assert_eq!(
-            claim_status.unlocked_amount(curr_ts, start_ts, end_ts),
-            Ok(0)
-        );
-    }
-
-    #[test]
-    fn test_start_greater_than_end() {
-        let claim_status = ClaimStatus {
-            locked_amount: 100,
-            ..Default::default()
-        };
-        let start_ts = 100;
-        let end_ts = 50;
-
-        assert_eq!(claim_status.unlocked_amount(75, start_ts, end_ts), Ok(0));
-    }
-
-    #[test]
-    fn test_partial_withdraw() {
-        for (curr_ts, expected, locked_amount_withdrawn) in [
-            (0, 0, 0),     // nothing vested, nothing to withdraw, nothing withdrawable
-            (10, 0, 10),   // 1/10th vested, 1/10th withdrawn, nothing withdrawable
-            (20, 0, 20),   // 2/10th vested, 2/10th withdrawn, nothing withdrawable
-            (50, 0, 50),   // 5/10th vested, 5/10th withdrawn, nothing withdrawable
-            (50, 25, 25),  // 5/10th vested, 2.5/10th withdrawn, 25 withdrawable
-            (70, 10, 60),  // 7/10th vested, 6/10th withdrawn, 10 withdrawable
-            (100, 90, 10), // 10/10th vested, 9/10th withdrawn, 10 withdrawable
-            (100, 0, 100), // 10/10th vested, 10/10th withdrawn, nothing withdrawable
-        ] {
-            let claim_status = ClaimStatus {
-                claimant: Pubkey::new_unique(),
-                locked_amount: 100,
-                unlocked_amount: 0,
-                locked_amount_withdrawn,
-            };
-
-            assert_eq!(
-                claim_status.amount_withdrawable(curr_ts, 0, 100),
-                Ok(expected)
-            );
         }
     }
 }

--- a/programs/merkle-distributor/src/state/merkle_distributor.rs
+++ b/programs/merkle-distributor/src/state/merkle_distributor.rs
@@ -39,6 +39,8 @@ pub struct MerkleDistributor {
     pub clawed_back: bool,
     /// this merkle tree is enable from this slot
     pub enable_slot: u64,
+    /// indicate that whether admin can close this pool, for testing purpose
+    pub closable: bool,
     /// Buffer 0
     pub buffer_0: [u8; 32],
     /// Buffer 1

--- a/target/types/merkle_distributor.ts
+++ b/target/types/merkle_distributor.ts
@@ -149,6 +149,10 @@ export type MerkleDistributor = {
         {
           "name": "enableSlot",
           "type": "u64"
+        },
+        {
+          "name": "closable",
+          "type": "bool"
         }
       ]
     },
@@ -217,7 +221,8 @@ export type MerkleDistributor = {
           "isMut": true,
           "isSigner": false,
           "relations": [
-            "claimant"
+            "claimant",
+            "admin"
           ]
         },
         {
@@ -592,6 +597,20 @@ export type MerkleDistributor = {
               "Unlocked amount"
             ],
             "type": "u64"
+          },
+          {
+            "name": "closable",
+            "docs": [
+              "indicate that whether admin can close this account, for testing purpose"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "admin",
+            "docs": [
+              "admin of merkle tree, store for for testing purpose"
+            ],
+            "type": "publicKey"
           }
         ]
       }
@@ -720,6 +739,13 @@ export type MerkleDistributor = {
               "this merkle tree is enable from this slot"
             ],
             "type": "u64"
+          },
+          {
+            "name": "closable",
+            "docs": [
+              "indicate that whether admin can close this pool, for testing purpose"
+            ],
+            "type": "bool"
           },
           {
             "name": "buffer0",
@@ -1053,6 +1079,10 @@ export const IDL: MerkleDistributor = {
         {
           "name": "enableSlot",
           "type": "u64"
+        },
+        {
+          "name": "closable",
+          "type": "bool"
         }
       ]
     },
@@ -1121,7 +1151,8 @@ export const IDL: MerkleDistributor = {
           "isMut": true,
           "isSigner": false,
           "relations": [
-            "claimant"
+            "claimant",
+            "admin"
           ]
         },
         {
@@ -1496,6 +1527,20 @@ export const IDL: MerkleDistributor = {
               "Unlocked amount"
             ],
             "type": "u64"
+          },
+          {
+            "name": "closable",
+            "docs": [
+              "indicate that whether admin can close this account, for testing purpose"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "admin",
+            "docs": [
+              "admin of merkle tree, store for for testing purpose"
+            ],
+            "type": "publicKey"
           }
         ]
       }
@@ -1624,6 +1669,13 @@ export const IDL: MerkleDistributor = {
               "this merkle tree is enable from this slot"
             ],
             "type": "u64"
+          },
+          {
+            "name": "closable",
+            "docs": [
+              "indicate that whether admin can close this pool, for testing purpose"
+            ],
+            "type": "bool"
           },
           {
             "name": "buffer0",


### PR DESCRIPTION
Previously in program we have feature test to allow admin can close merkle tree account and claim status, that would help reset testing. In the launch day, we need to deploy program without that feature for security issue

However it is not efficient, when Jupiter may conduct both meme coins and internal testing at the same time. For meme coins testing, we cannot close distributor, so that may conflict with test feature in program

The PR aims to fix that by moving flag closable in distrbutor account state and claim status account state. When initializing, admin can specify whether the distributor is closable or not.